### PR TITLE
add default platform type.

### DIFF
--- a/ALSystemUtilities/ALSystemUtilities/ALHardware/ALHardware.m
+++ b/ALSystemUtilities/ALSystemUtilities/ALHardware/ALHardware.m
@@ -96,6 +96,16 @@
     if ([result isEqualToString:@"iPhone7,2"])      type = @"iPhone 6";
     if ([result isEqualToString:@"iPhone7,1"])      type = @"iPhone 6 Plus";
     
+    if (!type) {
+        NSInteger index = MAX([result rangeOfString:@"iPhone"].length, [result rangeOfString:@"iPad"].length);
+        if (index == 0) {
+            index = [result rangeOfString:@"iPod"].length;
+        }
+        if (index > 0) {
+            type = [result substringToIndex:index];
+        }
+    }
+    
     return type;
 }
 


### PR DESCRIPTION
So the ``[ALHardware platformType]`` always returns a user readable value